### PR TITLE
New Feature: Option to Hide Empty Journal Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,45 +26,49 @@
 - ## Feature Introduction
   >  **see more details [👉🏻👉🏻here](https://github.com/duiliuliu/logseq-plugin-files-manager/discussions)**
   
-  1. **Card View and List View**
+	1. **Card View and List View**
 	- You can switch the display method in settings, displaying files in card or list form, providing a more intuitive file preview and operation interface.
 	- ![卡片视图](./images/app-card-en.png)
 	- 卡片与列表切换：![卡片与列表切换](./images/app-card-switch-en.png)
 	  
-	  2. **Right-Click Menu**
+	2. **Right-Click Menu**
 	- While viewing the list, users can trigger a comprehensive menu of functions by right-clicking on any file entry. This menu offers quick access to common file operations, making file management more efficient and convenient.
 	- ![rightMouseMenu](./images/right-mouse-menu.png)
 	  
-	  3. **Open Files**
+	3. **Open Files**
 	- Directly open Logseq files within Logseq.
 	- Attachment files will be opened based on their file type: PDF files will open within Logseq, while other file types will open using the default system program.
 	  
-	  4. **Copy File Path**
+	4. **Copy File Path**
 	- One-click copy of the complete file path for quick access in other applications.
 	  
-	  5. **Search Files**
+	5. **Search Files**
 	- A quick search function to help you locate the required files among a large number of files.
 	  
-	  6. **File Preview**
+	6. **File Preview**
 	- You can click on the file name to preview the file content. Please note: Due to browser limitations, some files may not support preview.
 	- ![文件预览](./images/app-preview.jpg)
 	- Double-click the filename to copy the filename for previewed files.
 	  
-	  7. **File Deletion**
+	7. **File Deletion**
 	- By clicking the "Delete" button, the file will be permanently removed, and the names of all associated files will be automatically replaced. The deletion process will be meticulously documented.
 	- Style of document reference after deletion: ![delete-page](./images/delete-page.png)
 	- Aggregated style of document reference after deletion: ![delete-page-hour](./images/delete-page-hour.png)
 	- Deletion and other operation logs: ![app-log](./images/app-log.png)
 	- You can now personalize the deletion style template through the settings to meet your specific needs ![delete-page-setting](./images/delete-page-setting.png)
 	  
-	  8. **Dynamic Property Configuration for New Pages**
-		- Empower your pages with pre-configured default properties that initialize on creation.
-		- Enhance your workflow by setting default properties for newly created pages. With the support of dynamic variables like randomIcon, you can further tailor the pages to your preferences. This feature allows you to craft pages with a rich set of customizable attributes that adapt to your specific requirements.
-		- ![page-default-props](./images/page-default-props-en.png)
+	8. **Dynamic Property Configuration for New Pages**
+	- Empower your pages with pre-configured default properties that initialize on creation.
+	- Enhance your workflow by setting default properties for newly created pages. With the support of dynamic variables like randomIcon, you can further tailor the pages to your preferences. This feature allows you to craft pages with a rich set of customizable attributes that adapt to your specific requirements.
+	- ![page-default-props](./images/page-default-props-en.png)
+
+	9. Hidden empty journal
+
 		  
-	  > Discover and experience more features awaiting your exploration.  **see more details [👉🏻👉🏻here](https://github.com/duiliuliu/logseq-plugin-files-manager/discussions)**
+	> Discover and experience more features awaiting your exploration.  **see more details [👉🏻👉🏻here](https://github.com/duiliuliu/logseq-plugin-files-manager/discussions)**
+
 	  
-	  ![app-log](./images/app-log.png)
+	![app-log](./images/app-log.png)
 - ### Development Plan
   
   

--- a/README_CN.md
+++ b/README_CN.md
@@ -22,46 +22,49 @@
 - ## 功能介绍
   >  **更多功能&使用分享 [👉🏻👉🏻here](https://github.com/duiliuliu/logseq-plugin-files-manager/discussions)**
   
-  1. **卡片视图和列表视图**
+  	1. **卡片视图和列表视图**
 	- 可在设置中切换展示方式，以卡片或列表形式展示文件，提供更直观的文件预览和操作界面。
 	- ![卡片视图](./images/app-card.jpg)
 	- 卡片与列表切换：![卡片与列表切换](./images/app-card-switch.jpg)
 	  
-	  2. **右键菜单**
+	2. **右键菜单**
 	- 用户在浏览列表视图时，可以通过右键点击任何文件条目来触发一个全面的功能菜单。这个菜单提供了快速访问常用文件操作的途径，使得管理文件变得更加高效和便捷。
 	- ![rightMouseMenu](./images/right-mouse-menu.png)
 	  
-	  3. **打开文件**
+	3. **打开文件**
 	- 直接在Logseq中打开Logseq文件。
 	- 附件文件将根据文件类型打开：PDF文件将在Logseq内部打开，其他类型的文件将通过系统默认程序打开。
 	  
-	  4. **复制文件路径**
+	4. **复制文件路径**
 	- 一键复制文件的完整路径，方便在其他应用中快速访问。
 	  
-	  5. **检索文件**
+	5. **检索文件**
 	- 快速搜索功能，帮助您在大量文件中迅速定位所需文件。
 	  
-	  6. **文件预览**
+	6. **文件预览**
 	- 可点击文件名称预览文件内容, 点击空白地方可退出预览。请注意：由于浏览器限制，部分文件可能无法预览。
 	- ![文件预览](./images/app-preview.jpg)
 	- 对于预览的文件，双击文件名可复制文件名
 	  
-	  7. **文件删除**
+	7. **文件删除**
 	- 点击“删除”按钮，文件将被永久移除，所有关联的文件名将自动替换。操作过程会被详细记录。
 	- 删除后的文档引用样式：![delete-page](./images/delete-page.png)
 	- 删除后的文档集中引用样式：![delete-page-hour](./images/delete-page-hour.png)
 	- 操作日志记录：![app-log](./images/app-log.png)
 	- 您也可以在设置中自定义删除样式模板，满足个性化需求 ![delete-page-setting](./images/delete-page-setting.png)
 	  
-	  8. **新建页面的动态属性配置**
+	8. **新建页面的动态属性配置**
 	- 赋予您的页面预配置的默认属性，这些属性将在创建时初始化。
 	- 通过为新创建的页面设置默认属性来增强您的工作流程。借助如 randomIcon 这样的动态变量支持，您可以进一步定制页面。此功能使您能够创建具有丰富、可自定义属性的页面，以适应您的需求。
 	- ![page-default-props](./images/page-default-props.png)
 	  
-	  > 更多功能,期待您的探索和体验.**更多功能&使用分享 [👉🏻👉🏻here](https://github.com/duiliuliu/logseq-plugin-files-manager/discussions)**
+
+	9. 隐藏空白日记页
+
+	> 更多功能,期待您的探索和体验.**更多功能&使用分享 [👉🏻👉🏻here](https://github.com/duiliuliu/logseq-plugin-files-manager/discussions)**
 - ### 开发计划
 - [ ] 实现文件重命名功能
-- [ ] 添加删除无用附件的功能
+- [x] 添加删除无用附件的功能
   
   以下是针对待办事项（TODO）的中文润色版本，增加了详细的描述和使用场景：
 - ### TODO 列表

--- a/src/data/constants.tsx
+++ b/src/data/constants.tsx
@@ -132,9 +132,13 @@ export const i18n_CUSTOMS_VARIABLE_DATE_DESC = 'Custom variable config ${date} d
 export const i18n_CUSTOMS_VARIABLE_TIME_DESC = 'Custom variable config ${time} desc' // time变量说明：${date}会返回当前时间，格式固定为'HH:mm'
 
 
-export const i18n_META_BLOCK_CUSTOMS_COMMANDS_HEADING = 'Custom Commands Heading' // '定义自定义命令，支持其他插件调用使用，比如Text Wrapper插件, 可by`logseq-files-manager.models.test`调用命令并执行'
+export const i18n_META_BLOCK_CUSTOMS_COMMANDS_HEADING = 'Custom Commands Heading' // 定义自定义命令，支持其他插件调用使用，比如Text Wrapper插件, 可by`logseq-files-manager.models.test`调用命令并执行
 export const i18n_META_BLOCK_CUSTOMS_COMMAND_CONFIG = 'Custom Command Configuration'  // 自定义命令配置
 export const i18n_META_BLOCK_CUSTOMS_COMMANDS = 'Custom Commands' // 根据配置生成的自定义命令
+
+export const i18n_HIDDEN_EMPTY_JOURNALS = 'Hidden empty journals' // 主页\日记页隐藏空白journals
+export const i18n_HIDDEN_EMPTY_JOURNALS_SWITCH = 'Hidden empty journals switch'  // 隐藏空白journals开关，开启后，在日记页面会隐藏掉空白journals，您可通过手动创建日记页并跳转，或者by dayjs插件、calendar插件跳转空白的journals
+export const i18n_HIDDEN_EMPTY_JOURNALS_DAYS = 'Hidden empty journal days' // 隐藏最近x天的日期
 
 
 // ===================================================================================

--- a/src/data/prepareData.tsx
+++ b/src/data/prepareData.tsx
@@ -8,6 +8,7 @@ import { DB } from './db';
 import { AppConfig, DataItem } from './types';
 import { GRAPH_PREFIX, REG_ASSETS, REG_SPLIT, REG_TAG } from './constants';
 import { objUnderlineToSmallCamel } from '../utils/objectUtil';
+import { parse } from 'date-fns';
 
 // 准备页面数据的函数
 const preparePagesData = async ({ appConfig, dirHandle }: { appConfig: AppConfig; dirHandle: FileSystemDirectoryHandle | undefined; }) => {
@@ -89,7 +90,7 @@ export const processPage = async ({ pageE, dirHandle, appConfig, updated }: proc
             relatedType: RelatedType.BLOCK,
             relatedItemUuid: imageUuid
         }],
-        createdTime: pageE.properties?.createdTime,
+        createdTime: isJournal ? parse(pageE.journalDay! + '', 'yyyyMMdd', new Date()).getTime() : new Date(pageE.properties?.createdTime).getTime(),
         icon: pageE.properties?.icon
     });
 

--- a/src/i18n/cn.json
+++ b/src/i18n/cn.json
@@ -66,5 +66,8 @@
     "UI toolbar dropdown enhance desc": "解决Logseq UI工具栏下拉菜单无法滚动到最底部的问题，确保您可以顺畅地访问所有选项",
     "Custom Commands Heading": "定义可以被其他插件使用的自定义命令，例如`Text Wrapper`\\`Full House Templates`插件，可通过`logseq-files-manager.models.test`调用命令并执行",
     "Custom Command Configuration": "自定义命令配置",
-    "Custom Commands": "根据配置生成的自定义命令，创建后，您可以轻松地复制这些命令并与其他插件一起使用它们"
+    "Custom Commands": "根据配置生成的自定义命令，创建后，您可以轻松地复制这些命令并与其他插件一起使用它们",
+    "Hidden empty journals": "隐藏空白日记",
+    "Hidden empty journals switch": "空白日记隐藏开关，开启后，日记页面将隐藏空白日记。您可以手动创建日记并跳转，或使用 Day.js 插件或日历插件访问空白日记",
+    "Hidden empty journal days": "隐藏最近 X 天的空白日记"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -66,5 +66,8 @@
     "UI toolbar dropdown enhance desc": "Address the issue of Logseq UI toolbar dropdown not being able to scroll to the bottom, ensuring you have seamless access to all options",
     "Custom Commands Heading": "Define custom commands that can be used by other plugins, such as the `Text Wrapper`\\`Full House Templates` plugin, and can be executed by calling commands like `logseq-files-manager.models.test`",
     "Custom Command Configuration": "Custom command configuration",
-    "Custom Commands": "Custom commands are generated based on your configuration settings. Once created, you can easily copy these commands and utilize them with other plugins"
+    "Custom Commands": "Custom commands are generated based on your configuration settings. Once created, you can easily copy these commands and utilize them with other plugins",
+    "Hidden empty journals": "Hide empty journals",
+    "Hidden empty journals switch": "Toggle to hide empty journals. When enabled, empty journals will be hidden on the diary page. You can manually create diary entries and navigate to them, or use the Day.js or calendar plugins to access empty journals",
+    "Hidden empty journal days": "Hide emty journals for the past X days"
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -66,5 +66,8 @@
     "UI toolbar dropdown enhance desc": "Logseq UIツールバードロップダウンが最下部までスクロールできない問題を解決し、すべてのオプションにシームレスにアクセスできるようにします",
     "Custom Commands Heading": "他のプラグインで使用できるカスタムコマンドを定義します。例えば、`Text Wrapper`\\`Full House Templates`プラグインで、`logseq-files-manager.models.test` コマンドを呼び出して実行できます",
     "Custom Command Configuration": "カスタムコマンドの設定",
-    "Custom Commands": "設定に基づいてカスタムコマンドが生成されます。その後、他のプラグインでコピーして使用することができます"
+    "Custom Commands": "設定に基づいてカスタムコマンドが生成されます。その後、他のプラグインでコピーして使用することができます",
+    "Hidden empty journals": "空のジャーナルを非表示",
+    "Hidden empty journals switch": "空のジャーナルを非表示にするスイッチ。これを有効にすると、日記ページで空のジャーナルが非表示になります。手動で日記を作成して移動するか、Day.js プラグインやカレンダープラグインを使用して空のジャーナルにアクセスできます",
+    "Hidden empty journal days": "最近 X 日間の空のジャーナルを非表示にする"
 }

--- a/src/logseq/feat/logseqEnhancePropsIcon.tsx
+++ b/src/logseq/feat/logseqEnhancePropsIcon.tsx
@@ -37,14 +37,14 @@ export const stopPropsIconObserver = () => {
     propsIconObserver?.disconnect();
 }
 
-export const inValidRoutes = new Set([PLUGIN_ROUTE, SETTING_ROUTE, LOG_ROUTE, CALENDAR_ROUTE]);
-export const validRoutes = new Set(['#/', '#/homepage', '#/home_page', '#/all-journals']);
+const inValidRoutes = new Set([PLUGIN_ROUTE, SETTING_ROUTE, LOG_ROUTE, CALENDAR_ROUTE]);
+const validRoutes = new Set(['#/', '#/homepage', '#/home_page', '#/all-journals']);
 
 /**
  * MutationObserver的回调函数，用于处理DOM变化
  * @param mutationsList - 变化列表
  */
-export const PropsIconObserverCallback: MutationCallback = (mutationsList) => {
+const PropsIconObserverCallback: MutationCallback = (mutationsList) => {
     logger.debug('PropsIconObserverCallback start')
     const route = parent?.document?.location.hash;
     logger.debug(`PropsIconObserverCallback route:${route}`)
@@ -83,7 +83,7 @@ export const stopEnhanceLspPluginDropdown = () => {
     try {
         logger.debug('stopEnhanceLspPluginDropdown')
         const node = parent?.document?.head.querySelector(`style[data-injected-style^="${ICON_PARENT_STYLE_KEY}"]`)
-        node && node.remove()
+        node?.remove()
     } catch (error) {
 
     }

--- a/src/logseq/feat/logseqHiddenEmptyJournal.tsx
+++ b/src/logseq/feat/logseqHiddenEmptyJournal.tsx
@@ -1,0 +1,131 @@
+import { format } from "date-fns";
+import { PARENT_MAIN_CONTAINER_ID } from "../../data/constants";
+import { DB } from "../../data/db";
+import { DataType } from "../../data/enums";
+import { logger } from "../../utils/logger";
+import { AppConfig } from "../../data/types";
+
+
+let emptyJournals: string[] = []
+let currentDay = -1
+let graph_cache = ''
+let dateFormat_cahce = ''
+let days_cache = 0
+let hasHiddenJournals = 0
+// 定义全局的 MutationObserver 和其配置对象
+let hiddenEmptyJournalObserver: MutationObserver;
+let hiddenEmptyJournalObserverConfig: MutationObserverInit;
+
+/**
+ * MutationObserver的回调函数，用于处理DOM变化
+ * @param mutationsList - 变化列表
+ */
+const hiddenEmptyJournalCallBack: MutationCallback = (mutationsList) => {
+    logger.debug('hiddenEmptyJournalCallBack start')
+    const route = parent?.document?.location.hash;
+
+    if (route && (route === '#/all-journals' || route === '#/' || route === '#/homepage')) {
+        if (hasHiddenJournals === emptyJournals.length && emptyJournals.length != 0) {
+            return
+        }
+        mutationsList.forEach(async (mutation) => {
+            const addedNode = mutation.addedNodes[0] as HTMLElement;
+            if (addedNode && addedNode.childNodes.length) {
+                await doHiddenEmptyJournal()
+            }
+        });
+    } else {
+        hasHiddenJournals = 0
+    }
+};
+
+const doHiddenEmptyJournal = async () => {
+    if (currentDay != new Date().getDay() || emptyJournals.length === 0) {
+        currentDay = new Date().getDay()
+        emptyJournals = await getEmptyJournal(graph_cache, dateFormat_cahce, days_cache)
+    }
+
+    const appContainer = parent?.document?.getElementById(PARENT_MAIN_CONTAINER_ID);
+    appContainer && emptyJournals.forEach(item => {
+        const id = "#" + CSS.escape(item)
+        const divEl = appContainer?.querySelector(id)?.closest('div.journal-item.content') as HTMLDivElement
+        if (divEl && divEl.style.display != 'none') {
+            divEl.style.display = 'none';
+            hasHiddenJournals++
+        }
+    })
+}
+
+/**
+ * 优化插件下拉菜单滚动问题
+ */
+export const openHiddenEmptyJournal = async (appConfig: AppConfig) => {
+    logger.debug('openHiddenEmptyJournal')
+
+    if (!hiddenEmptyJournalObserver) {
+        hiddenEmptyJournalObserverConfig = { childList: true, subtree: true, };
+        hiddenEmptyJournalObserver = new MutationObserver(hiddenEmptyJournalCallBack);
+        if (!appConfig.pluginSettings?.hiddenEmptyJournalDays) {
+            return
+        }
+        emptyJournals = await getEmptyJournal(appConfig.currentGraph, appConfig.preferredDateFormat, appConfig.pluginSettings?.hiddenEmptyJournalDays)
+        currentDay = new Date().getDay()
+
+        await doHiddenEmptyJournal()
+    }
+
+    const appContainer = parent?.document?.getElementById(PARENT_MAIN_CONTAINER_ID);
+    if (appContainer && hiddenEmptyJournalObserver) {
+        logger.debug('hiddenEmptyJournalObserver observe');
+        hiddenEmptyJournalObserver.observe(appContainer, hiddenEmptyJournalObserverConfig);
+    }
+
+    if (appConfig.currentGraph && appConfig.currentGraph != graph_cache) {
+        graph_cache = appConfig.currentGraph
+        dateFormat_cahce = appConfig.preferredDateFormat
+        days_cache = appConfig.pluginSettings?.hiddenEmptyJournalDays || 14
+    }
+}
+
+/**
+ * 关闭优化插件下拉菜单滚动问题
+ */
+export const stopHiddenEmptyJournal = () => {
+    emptyJournals = []
+    currentDay = -1
+    logger.debug('stopPropsIconObserver start')
+    hiddenEmptyJournalObserver?.disconnect();
+}
+
+const getEmptyJournal = async (graph: string, dateFormat: string, days: number,) => {
+    if (!graph) {
+        return []
+    }
+
+    const dataType = DataType.JOURNAL.toString()
+    const data = await DB.data
+        // .where( { graph, dataType } )
+        .where({ graph, dataType })
+        .reverse()
+        .limit(30)
+        .sortBy('createdTime');
+    const hasDataJournalSet = new Set(data.map(item => item.alias))
+    const last30Days = generateLast30DaysDates(dateFormat, days,)
+    const result = last30Days.filter(item => !hasDataJournalSet.has(item))
+    return result;
+
+}
+
+const generateLast30DaysDates = (dateFormat: string, days: number,) => {
+    const currentDate = new Date(); // 获取当前日期
+    const dates = []; // 存储日期的数组
+
+    // 向后构造最近30天的日期
+    for (let i = 1; i < days; i++) {
+        const dayDate = new Date(currentDate.getTime() - (i * 24 * 60 * 60 * 1000)); // 当前天减去i天 
+        // 将日期格式化为'yyyy-MM-dd'格式并添加到数组中
+        dates.push(format(dayDate, dateFormat));
+    }
+
+    return dates;
+}

--- a/src/logseq/logseqSetting.tsx
+++ b/src/logseq/logseqSetting.tsx
@@ -1,5 +1,5 @@
 import { SettingSchemaDesc } from '@logseq/libs/dist/LSPlugin';
-import { EXTERNAL_PLUGIN_AWESOME_PROPS, i18n_DEFAULT_DELETE_FORMAT, i18n_GET_PLUGIN_CONFIG_ERROR, i18n_OPEN_PLUGN_SETTING_TOOLTIP, i18n_CUSTOMS_VARIABLE_DATE_DESC, i18n_CUSTOMS_VARIABLE_DESC, i18n_CUSTOMS_VARIABLE_RANDOMICON_DESC, i18n_CUSTOMS_VARIABLE_TIME_DESC, i18n_CUSTOMS_VARIABLE_TITLE, i18n_CUSTOMS_VARIABLE_VAR_DESC, i18n_DELETE_FORMAT_DESC, i18n_DELETE_FORMAT_TITLE, i18n_DELETE_FORMAT_VAR_DESC, i18n_PAGE_DEFAULT_PROPS_DESC, i18n_PAGE_DEFAULT_PROPS_TITLE, i18n_PAGE_DEFAULT_PROPS_VAR_DESC, i18n_PAGE_DEFAULT_PROPS_VISIBLE_DESC, i18n_PROPS_ICON_DESC, i18n_PROPS_ICON_TITLE, i18n_UI_TOOLBAR_DROPDOWN_DESC, i18n_UI_TOOLBAR_DROPDOWN_TITLE, SETTING_ROUTE, i18n_CUSTOMS_VARIABLE_TIMEOUT_DESC, i18n_CUSTOMS_VARIABLE_ERROR_HANDLER_DESC, i18n_META_BLOCK_CUSTOMS_COMMAND_CONFIG, i18n_META_BLOCK_CUSTOMS_COMMANDS, i18n_META_BLOCK_CUSTOMS_COMMANDS_HEADING } from '../data/constants';
+import { EXTERNAL_PLUGIN_AWESOME_PROPS, i18n_DEFAULT_DELETE_FORMAT, i18n_GET_PLUGIN_CONFIG_ERROR, i18n_OPEN_PLUGN_SETTING_TOOLTIP, i18n_CUSTOMS_VARIABLE_DATE_DESC, i18n_CUSTOMS_VARIABLE_DESC, i18n_CUSTOMS_VARIABLE_RANDOMICON_DESC, i18n_CUSTOMS_VARIABLE_TIME_DESC, i18n_CUSTOMS_VARIABLE_TITLE, i18n_CUSTOMS_VARIABLE_VAR_DESC, i18n_DELETE_FORMAT_DESC, i18n_DELETE_FORMAT_TITLE, i18n_DELETE_FORMAT_VAR_DESC, i18n_PAGE_DEFAULT_PROPS_DESC, i18n_PAGE_DEFAULT_PROPS_TITLE, i18n_PAGE_DEFAULT_PROPS_VAR_DESC, i18n_PAGE_DEFAULT_PROPS_VISIBLE_DESC, i18n_PROPS_ICON_DESC, i18n_PROPS_ICON_TITLE, i18n_UI_TOOLBAR_DROPDOWN_DESC, i18n_UI_TOOLBAR_DROPDOWN_TITLE, SETTING_ROUTE, i18n_CUSTOMS_VARIABLE_TIMEOUT_DESC, i18n_CUSTOMS_VARIABLE_ERROR_HANDLER_DESC, i18n_META_BLOCK_CUSTOMS_COMMAND_CONFIG, i18n_META_BLOCK_CUSTOMS_COMMANDS, i18n_META_BLOCK_CUSTOMS_COMMANDS_HEADING, i18n_HIDDEN_EMPTY_JOURNALS, i18n_HIDDEN_EMPTY_JOURNALS_SWITCH, i18n_HIDDEN_EMPTY_JOURNALS_DAYS } from '../data/constants';
 import getI18nConstant, { PRE_LANGUAGE } from '../i18n/utils';
 import { stringToVarArr, stringToObject } from '../utils/objectUtil';
 import { logger } from '../utils/logger';
@@ -24,6 +24,8 @@ export interface PluginSettings {
     enhanceUIToolbarDropdown: boolean;
     metaBlockCustomsCommandConfig: { [K: string]: createMetaBlockProps }
     metaBlockCustomsCommands: string[]
+    hiddenEmptyJournalsSwith: boolean;
+    hiddenEmptyJournalDays: number;
 }
 
 const DEFAULT_SETTINGS = {
@@ -77,7 +79,9 @@ const DEFAULT_SETTINGS = {
             }
         }
     },
-    metaBlockCustomsCommands: []
+    metaBlockCustomsCommands: [],
+    hiddenEmptyJournalsSwith: false,
+    hiddenEmptyJournalDays: 14,
 }
 
 
@@ -86,6 +90,28 @@ export const initLspSettingsSchema = async (lang?: string,) => {
     !lang && ({ preferredLanguage: lang } = await logseq.App.getUserConfigs())
 
     const schemas: SettingSchemaDesc[] = [
+        {
+            key: 'hiddenEmptyJournalsHeading',
+            title: getI18nConstant(lang, i18n_HIDDEN_EMPTY_JOURNALS),
+            description: '',
+            type: 'heading',
+            default: null,
+        },
+        {
+            key: 'hiddenEmptyJournalsSwith',
+            title: '',
+            type: 'boolean',
+            default: false,
+            description: getI18nConstant(lang, i18n_HIDDEN_EMPTY_JOURNALS_SWITCH),
+        },
+        {
+            key: 'hiddenEmptyJournalDays',
+            title: getI18nConstant(lang, i18n_HIDDEN_EMPTY_JOURNALS_DAYS),
+            description: '',
+            type: 'number',
+            default: 14,
+        },
+
         {
             key: 'deleteFormartHeading',
             title: getI18nConstant(lang, i18n_DELETE_FORMAT_TITLE),
@@ -311,7 +337,9 @@ export const getPluginSettings = async (): Promise<PluginSettings> => {
         propsIconConfig: await getPropsIconConfig(lspSettings),
         enhanceUIToolbarDropdown: lspSettings.enhanceUIToolbarDropdown,
         metaBlockCustomsCommandConfig: lspSettings.metaBlockCustomsCommandConfig,
-        metaBlockCustomsCommands: lspSettings.metaBlockCustomsCommands
+        metaBlockCustomsCommands: lspSettings.metaBlockCustomsCommands,
+        hiddenEmptyJournalsSwith: lspSettings.hiddenEmptyJournalsSwith,
+        hiddenEmptyJournalDays: lspSettings.hiddenEmptyJournalDays,
     }
 }
 

--- a/src/logseq/useUserConfigs.tsx
+++ b/src/logseq/useUserConfigs.tsx
@@ -10,6 +10,7 @@ import { getPluginSettings, initLspSettingsSchema } from './logseqSetting';
 import { initPropsIconObserver, runEnhanceLspPluginDropdown, runPropsIconObserver, stopEnhanceLspPluginDropdown, stopPropsIconObserver } from './feat/logseqEnhancePropsIcon';
 import { logseq as lsp } from '../../package.json';
 import { initMetaBlock } from './feat/logseqMetaBlock';
+import { openHiddenEmptyJournal, stopHiddenEmptyJournal } from './feat/logseqHiddenEmptyJournal';
 
 
 export const fetchUserConfigs = async (setUserConfigs?: (arg0: AppConfig) => void): Promise<AppConfig> => {
@@ -143,9 +144,20 @@ export const useUserConfigs = (userConfigUpdated: number) => {
         if (settings?.propsIconConfig && !userConfigs.propertyPagesEnable) {
             initPropsIconObserver()
             runPropsIconObserver()
+        } else {
+            stopPropsIconObserver()
         }
-        return () => { stopPropsIconObserver() }
     }, [userConfigs.propertyPagesEnabled, userConfigs?.pluginSettings?.propsIconConfig])
+
+    // 隐藏空白journals
+    useEffect(() => {
+        const settings = userConfigs?.pluginSettings
+        if (settings?.hiddenEmptyJournalsSwith && userConfigs.preferredDateFormat) {
+            openHiddenEmptyJournal(userConfigs)
+        } else {
+            stopHiddenEmptyJournal()
+        }
+    }, [userConfigs.preferredDateFormat, userConfigs?.pluginSettings?.hiddenEmptyJournalsSwith, userConfigs?.pluginSettings?.hiddenEmptyJournalDays])
 
     // 优化工具栏下拉框
     useEffect(() => {


### PR DESCRIPTION
 
We've introduced a convenient new feature that allows you to hide empty journal pages. This means a tidier journal experience for those who prefer not to see dates without entries. With just a flip of a switch, those blank pages will vanish, giving you a more focused and efficient way to engage with your journal. You can still access and create entries for those special days by manually adding journal pages or by using our Day.js and Calendar plugins.